### PR TITLE
Fix invalid thread access in ProgressChanged

### DIFF
--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -371,7 +371,8 @@ namespace Titan.ViewModels
 
         private void DatalogReader_ProgressChanged(object sender, DataLogReader.ProgressChangedEventArgs e)
         {
-            Progress = (int)(e.Progress * 100.0);
+            Dispatcher.UIThread.Post(() => Progress = (int)(e.Progress * 100.0));
+
         }
     }
 }


### PR DESCRIPTION
Progress is a variable on the main thread, however it is ran frum a standalone task, which is ran from the thread pool.